### PR TITLE
feat: add `ExecCommand` for running terminal subprocesses

### DIFF
--- a/demo/exec
+++ b/demo/exec
@@ -7,22 +7,11 @@
 require "bundler/setup"
 require "bubbletea"
 
-class EditorFinishedMessage < Bubbletea::Message
-  attr_reader :error
-
-  def initialize(error = nil)
-    super()
-
-    @error = error
-  end
-end
-
 class ExecDemo
   include Bubbletea::Model
 
   def initialize
     @altscreen_active = false
-    @error = nil
   end
 
   def init
@@ -39,37 +28,19 @@ class ExecDemo
 
         return [self, cmd]
       when "e"
-        return [self, open_editor]
+        editor = ENV["EDITOR"] || "vim"
+        return [self, Bubbletea.exec(-> { system(editor) })]
       when "ctrl+c", "q"
         return [self, Bubbletea.quit]
       end
 
-    when EditorFinishedMessage
-      if message.error
-        @error = message.error
-        return [self, Bubbletea.quit]
-      end
     end
 
     [self, nil]
   end
 
   def view
-    return "Error: #{@error}\n" if @error
-
     "Press 'e' to open your EDITOR.\nPress 'a' to toggle the altscreen\nPress 'q' to quit.\n"
-  end
-
-  private
-
-  def open_editor
-    lambda do
-      editor = ENV["EDITOR"] || "vim"
-      system(editor)
-      EditorFinishedMessage.new
-    rescue StandardError => e
-      EditorFinishedMessage.new(e.message)
-    end
   end
 end
 

--- a/lib/bubbletea/commands.rb
+++ b/lib/bubbletea/commands.rb
@@ -78,6 +78,16 @@ module Bubbletea
   class SuspendCommand < Command
   end
 
+  class ExecCommand < Command
+    attr_reader :callable, :message
+
+    def initialize(callable, message: nil)
+      super()
+      @callable = callable
+      @message = message
+    end
+  end
+
   class << self
     def quit
       QuitCommand.new
@@ -121,6 +131,10 @@ module Bubbletea
 
     def suspend
       SuspendCommand.new
+    end
+
+    def exec(callable, message: nil)
+      ExecCommand.new(callable, message: message)
     end
   end
 end

--- a/lib/bubbletea/runner.rb
+++ b/lib/bubbletea/runner.rb
@@ -233,6 +233,9 @@ module Bubbletea
       when SuspendCommand
         suspend_process
 
+      when ExecCommand
+        exec_process(command)
+
       when Proc
         Thread.new do
           result = command.call
@@ -285,6 +288,9 @@ module Bubbletea
 
       when SuspendCommand
         suspend_process
+
+      when ExecCommand
+        exec_process(command)
 
       when Proc
         result = command.call
@@ -358,6 +364,23 @@ module Bubbletea
       @program.enable_mouse_all_motion if @options[:mouse_all_motion]
 
       handle_message(ResumeMessage.new)
+    end
+
+    def exec_process(command)
+      @program.disable_mouse if @options[:mouse_cell_motion] || @options[:mouse_all_motion]
+      @program.show_cursor
+      @program.stop_input_reader
+      @program.exit_raw_mode
+
+      command.callable.call
+
+      @program.enter_raw_mode
+      @program.hide_cursor
+      @program.start_input_reader
+      @program.enable_mouse_cell_motion if @options[:mouse_cell_motion]
+      @program.enable_mouse_all_motion if @options[:mouse_all_motion]
+
+      handle_message(command.message) if command.message
     end
 
     def render

--- a/test/runner_test.rb
+++ b/test/runner_test.rb
@@ -160,4 +160,39 @@ class TestRunnerCommandProcessing < Minitest::Spec
   it "process nil command" do
     @runner.__send__(:process_command, nil)
   end
+
+  it "process exec command calls callable" do
+    called = false
+    callable = -> { called = true }
+
+    program = Object.new
+    [:disable_mouse, :show_cursor, :stop_input_reader, :exit_raw_mode, :enter_raw_mode, :hide_cursor, :start_input_reader].each do |method|
+      program.define_singleton_method(method) { nil }
+    end
+
+    @runner.instance_variable_set(:@program, program)
+
+    cmd = Bubbletea.exec(callable)
+    @runner.__send__(:process_command, cmd)
+
+    assert called
+  end
+
+  it "process exec command dispatches message" do
+    called = false
+    callable = -> { called = true }
+
+    program = Object.new
+    [:disable_mouse, :show_cursor, :stop_input_reader, :exit_raw_mode, :enter_raw_mode, :hide_cursor, :start_input_reader].each do |method|
+      program.define_singleton_method(method) { nil }
+    end
+
+    @runner.instance_variable_set(:@program, program)
+
+    cmd = Bubbletea.exec(callable, message: :exec_done)
+    @runner.__send__(:process_command, cmd)
+
+    assert called
+    assert_includes @model.messages, :exec_done
+  end
 end


### PR DESCRIPTION
## What

Adds `Bubbletea.exec(callable, message:)` which suspends terminal management, runs a callable, then restores terminal state. This enables spawning editors, pagers, and other TUI subprocesses cleanly, similar to Go bubbletea's `tea.Exec`.

## Testing

The tests in this project seem fairly early, I initially had mocks which I didn't love but we don't have a mock dependency so I used an object. It's not pretty but felt better than no tests. I didn't know if you had a plan for testing so kept this light. Let me know if you want me to make any improvements.